### PR TITLE
Use NimBLE-Arduino 2.x

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ build_flags =
 board = lolin_s3
 lib_deps =
 	ArduinoFake
-	h2zero/NimBLE-Arduino@^2.1.3
+	h2zero/NimBLE-Arduino@^2.2.1
 lib_compat_mode = off
 build_unflags =
 	-std=gnu++11

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ build_flags =
 board = lolin_s3
 lib_deps =
 	ArduinoFake
-	h2zero/NimBLE-Arduino@^1.4.1
+	h2zero/NimBLE-Arduino@^2.1.3
 lib_compat_mode = off
 build_unflags =
 	-std=gnu++11

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -91,7 +91,7 @@ void RemoteScalesScanner::initializeAsyncScan() {
   // We set the second parameter to true to prevent the library from storing BLEAdvertisedDevice objects
   // for devices we're not interested in. This is important because the library will otherwise run out of
   // memory after a while.
-  NimBLEDevice::getScan()->setAdvertisedDeviceCallbacks(this, true);
+  NimBLEDevice::getScan()->setScanCallbacks(this, true);
   NimBLEDevice::getScan()->setInterval(500);
   NimBLEDevice::getScan()->setWindow(100);
   NimBLEDevice::getScan()->setMaxResults(0);

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -114,7 +114,7 @@ void RemoteScalesScanner::restartAsyncScan() {
   initializeAsyncScan();
 }
 
-void RemoteScalesScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
+void RemoteScalesScanner::onResult(const NimBLEAdvertisedDevice* advertisedDevice) {
   std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getBase()), 6);
   if (alreadySeenAddresses.exists(addrStr)) {
     return;

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -97,7 +97,7 @@ void RemoteScalesScanner::initializeAsyncScan() {
   NimBLEDevice::getScan()->setMaxResults(0);
   NimBLEDevice::getScan()->setDuplicateFilter(false);
   NimBLEDevice::getScan()->setActiveScan(false);
-  NimBLEDevice::getScan()->start(0, false, false); // Set to 0 for continuous
+  NimBLEDevice::getScan()->start(0); // Set to 0 for continuous
   isRunning = true;
 }
 

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -115,7 +115,7 @@ void RemoteScalesScanner::restartAsyncScan() {
 }
 
 void RemoteScalesScanner::onResult(NimBLEAdvertisedDevice* advertisedDevice) {
-  std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getNative()), 6);
+  std::string addrStr(reinterpret_cast<const char*>(advertisedDevice->getAddress().getBase()), 6);
   if (alreadySeenAddresses.exists(addrStr)) {
     return;
   }

--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -97,7 +97,7 @@ void RemoteScalesScanner::initializeAsyncScan() {
   NimBLEDevice::getScan()->setMaxResults(0);
   NimBLEDevice::getScan()->setDuplicateFilter(false);
   NimBLEDevice::getScan()->setActiveScan(false);
-  NimBLEDevice::getScan()->start(0, nullptr, false); // Set to 0 for continuous
+  NimBLEDevice::getScan()->start(0, false, false); // Set to 0 for continuous
   isRunning = true;
 }
 

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -73,11 +73,11 @@ private:
   LRUCache alreadySeenAddresses = LRUCache(100);
   std::vector<DiscoveredDevice> discoveredScales;
   void cleanupDiscoveredScales();
+  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
 
 public:
   std::vector<DiscoveredDevice> getDiscoveredScales() { return discoveredScales; }
 
-  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
   void initializeAsyncScan();
   void stopAsyncScan();
   void restartAsyncScan();

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -8,7 +8,7 @@
 
 class DiscoveredDevice {
 public:
-  DiscoveredDevice(NimBLEAdvertisedDevice* device) : 
+  DiscoveredDevice(const NimBLEAdvertisedDevice* device) : 
   name(device->getName()), address(device->getAddress()), manufacturerData(device->getManufacturerData()) {}
   const std::string& getName() const { return name; }
   const NimBLEAddress& getAddress() const { return address; }

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -67,7 +67,7 @@ private:
 // ---------------------------------------------------------------------------------------
 // ---------------------------   RemoteScalesScanner    -----------------------------------
 // ---------------------------------------------------------------------------------------
-class RemoteScalesScanner : public NimBLEAdvertisedDeviceCallbacks {
+class RemoteScalesScanner : public NimBLEScanCallbacks {
 private:
   bool isRunning = false;
   LRUCache alreadySeenAddresses = LRUCache(100);

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -73,7 +73,7 @@ private:
   LRUCache alreadySeenAddresses = LRUCache(100);
   std::vector<DiscoveredDevice> discoveredScales;
   void cleanupDiscoveredScales();
-  void onResult(NimBLEAdvertisedDevice* advertisedDevice);
+  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
 
 public:
   std::vector<DiscoveredDevice> getDiscoveredScales() { return discoveredScales; }

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -73,11 +73,11 @@ private:
   LRUCache alreadySeenAddresses = LRUCache(100);
   std::vector<DiscoveredDevice> discoveredScales;
   void cleanupDiscoveredScales();
-  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
 
 public:
   std::vector<DiscoveredDevice> getDiscoveredScales() { return discoveredScales; }
 
+  void onResult(const NimBLEAdvertisedDevice* advertisedDevice) override;
   void initializeAsyncScan();
   void stopAsyncScan();
   void restartAsyncScan();

--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -59,8 +59,8 @@ private:
 
   NimBLEClient* client = nullptr;
   DiscoveredDevice device;
-  LogCallback logCallback;
-  WeightCallback weightCallback;
+  LogCallback logCallback = nullptr;
+  WeightCallback weightCallback = nullptr;
   bool weightCallbackOnlyChanges = false;
 };
 


### PR DESCRIPTION
> Nearly all of the codebase has been updated and changed under the surface, which has **greatly reduced the resource use of the library and improved it's performance**.

Sounds good.

Changes:
* function signatures updated per [migration guide](https://github.com/h2zero/NimBLE-Arduino/blob/master/docs/1.x_to2.x_migration_guide.md).
* initialized the log and weight callback pointers to null (maybe unnecessary, but was unable to test without this fix due to a crash in `setWeight()` presumably caused by using the uninitialized pointer).

Tested with a varia bluetooth scale and temporary `main.cpp`.