### PR TITLE
Change the scan mode to ACTIVE

### DIFF
--- a/src/remote_scales.cpp
+++ b/src/remote_scales.cpp
@@ -96,7 +96,7 @@ void RemoteScalesScanner::initializeAsyncScan() {
   NimBLEDevice::getScan()->setWindow(100);
   NimBLEDevice::getScan()->setMaxResults(0);
   NimBLEDevice::getScan()->setDuplicateFilter(false);
-  NimBLEDevice::getScan()->setActiveScan(false);
+  NimBLEDevice::getScan()->setActiveScan(true);
   NimBLEDevice::getScan()->start(0); // Set to 0 for continuous
   isRunning = true;
 }


### PR DESCRIPTION
Some devices (specifically the Varia) don't provide a `name` string when scanning in passive mode, preventing the scales code from detecting the device.

Any reason we can't use [active mode](https://h2zero.github.io/esp-nimble-cpp/class_nim_b_l_e_scan.html#a7d24e77d6b339552b6ac16effdb54910) here?

Discovered by testing on gaggiuino hardware: https://github.com/Zer0-bit/esp-arduino-ble-scales/pull/6#issuecomment-2683177022

---

Passive:

```
 - Addr: 50:e4:52:cf:cb:0b Name: ""
```

Active:

```
 - Addr: 50:e4:52:cf:cb:0b Name: "AKU MINI SCALE"
```

