### PR TITLE
Add support for Varia AKU Pro

### DIFF
--- a/src/scales/varia.h
+++ b/src/scales/varia.h
@@ -56,7 +56,8 @@ private:
     return !deviceName.empty() &&
       (
         deviceName.find("AKU MINI SCALE") == 0 ||
-        deviceName.find("VARIA AKU") == 0
+        deviceName.find("VARIA AKU") == 0 ||
+        deviceName.find("Varia AKU") == 0 //Match Varia AKU-PRO and Varia AKU-MICRO
       );
   }
 };


### PR DESCRIPTION
Adds support for Varia AKU Pro. Tested locally using an esp32. Of note, there seems to be a slight lag for tare of a little under 1s. I'm unsure if this will cause problems as the `tare()` function returns `true` immediately. I haven't changed this behavior and am unsure if the same lag exists in the other Varia scales.