### PR TITLE
Update confirmed Varia AKU scale names

### DIFF
--- a/src/scales/varia.h
+++ b/src/scales/varia.h
@@ -55,8 +55,8 @@ private:
     const std::string& deviceName = device.getName();
     return !deviceName.empty() &&
       (
-        deviceName.find("AKU MINI SCALE") == 0 ||
-        deviceName.find("VARIA AKU") == 0
+        deviceName.find("Varia AKU") == 0 ||
+        deviceName.find("AKU MINI SCALE") == 0
       );
   }
 };


### PR DESCRIPTION
This should cover the mini, micro and pro using confirmed name strings.

* AKU Mini: no change, `AKU MINI SCALE`
* AKU Micro: `Varia AKU-MICRO` https://github.com/Zer0-bit/esp-arduino-ble-scales/pull/15
* AKU Pro: `Varia AKU-PRO` [Discord help thread](https://discord.com/channels/890339612441063494/1323485517974732913/1351202206015033354)