### PR TITLE
add support for Timemore Black Mirror Dot scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This allows for easy extention of the library for more bluetooth enabled scales.
 * [INSMART 863A](https://www.amazon.com/INSMART-Coffee-Scale-with-Timer/dp/B0FRMQFNJ4) - [Tested]
 * [Solobarista](https://item.taobao.com/item.htm?id=848706090408&skuId=5805800327323&spm=a21xtw.29178619.0.0) - [Tested]
 * [Timemore Black Mirror DUO](https://www.timemore.com/collections/coffee-scale/products/timemore-coffee-scale-black-mirror-duo) - [Tested]
+* [Timemore Black Mirror Dot](https://e.tb.cn/h.RaauU1uixK6rBHE?tk=NKEx5psOlHb HU108) - [Tested]
 * [Varia AKU /Mini](https://www.variabrewing.com/products/varia-aku-scale) - [Tested]
 * [WeighMyBrew](https://github.com/031devstudios/weighmybru2) - [Tested]
 * [Smart Kitchen Scale / MyScale (Model: KP2048B)](https://aliexpress.com/item/1005005916581185.html) - [Tested]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This allows for easy extention of the library for more bluetooth enabled scales.
 * [INSMART 863A](https://www.amazon.com/INSMART-Coffee-Scale-with-Timer/dp/B0FRMQFNJ4) - [Tested]
 * [Solobarista](https://item.taobao.com/item.htm?id=848706090408&skuId=5805800327323&spm=a21xtw.29178619.0.0) - [Tested]
 * [Timemore Black Mirror DUO](https://www.timemore.com/collections/coffee-scale/products/timemore-coffee-scale-black-mirror-duo) - [Tested]
-* [Timemore Black Mirror Dot](https://e.tb.cn/h.RaauU1uixK6rBHE?tk=NKEx5psOlHb HU108) - [Tested]
+* [Timemore Black Mirror Dot](https://e.tb.cn/h.RaauU1uixK6rBHE?tk=NKEx5psOlHb) - [Tested]
 * [Varia AKU /Mini](https://www.variabrewing.com/products/varia-aku-scale) - [Tested]
 * [WeighMyBrew](https://github.com/031devstudios/weighmybru2) - [Tested]
 * [Smart Kitchen Scale / MyScale (Model: KP2048B)](https://aliexpress.com/item/1005005916581185.html) - [Tested]

--- a/src/scales/timemore_new.cpp
+++ b/src/scales/timemore_new.cpp
@@ -62,12 +62,22 @@ bool TimemoreNewScales::isConnected() {
 
 void TimemoreNewScales::update() {
     // 状态维护逻辑：如果在此周期发现断线，则触发重新连接
-    // connect() 内部自带了密钥冲突的重试容错机制
     if (!isConnected()) {
-        RemoteScales::log("Device disconnected. Attempting to reconnect...\n");
-        delay(1000); // 延时缓冲，给物理设备一些反应时间
-        if (connect()) {
-            RemoteScales::log("Reconnected to Timemore Dot successfully.\n");
+        // 使用静态变量记录上一次尝试重连的时间
+        static uint32_t lastReconnectAttempt = 0;
+        
+        // 智能节流：断线后，每隔 5 秒才进行一次重连尝试，而不是每毫秒都在死等
+        if (millis() - lastReconnectAttempt > 5000) {
+            RemoteScales::log("Device disconnected. Attempting to reconnect...\n");
+            
+            if (connect()) {
+                RemoteScales::log("Reconnected to Timemore Dot successfully.\n");
+            } else {
+                RemoteScales::log("Reconnect failed. Will retry in 5 seconds.\n");
+            }
+            
+            // 更新最后尝试的时间
+            lastReconnectAttempt = millis();
         }
     }
 }

--- a/src/scales/timemore_new.cpp
+++ b/src/scales/timemore_new.cpp
@@ -1,0 +1,245 @@
+#include "timemore_new.h"
+#include "remote_scales_plugin_registry.h"
+
+// 使用完整的 128-bit UUID 以确保最高兼容性
+const NimBLEUUID TIMEMORE_NEW_SERVICE_UUID("0000fff0-0000-1000-8000-00805f9b34fb");
+const NimBLEUUID TIMEMORE_NEW_NOTIFY_CHAR_UUID("0000fff1-0000-1000-8000-00805f9b34fb");
+const NimBLEUUID TIMEMORE_NEW_COMMAND_CHAR_UUID("0000fff2-0000-1000-8000-00805f9b34fb");
+
+// -----------------------------------------------------------------------------------
+// ---------------------------------   PUBLIC   --------------------------------------
+// -----------------------------------------------------------------------------------
+
+TimemoreNewScales::TimemoreNewScales(const DiscoveredDevice& device) : RemoteScales(device) {}
+
+bool TimemoreNewScales::connect() {
+    if (RemoteScales::clientIsConnected()) {
+        return true;
+    }
+
+    RemoteScales::log("Connecting to %s [%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
+
+    // 第一次连接尝试
+    bool result = RemoteScales::clientConnect();
+    
+    if (!result) {
+        // 【智能容错】：连接失败极有可能是电子秤被重置，导致旧的配对密钥(Bond)失效
+        RemoteScales::log("Connection failed. Attempting to delete old bond and retry...\n");
+        
+        // 精准删除这个特定 MAC 地址的本地配对记录
+        NimBLEDevice::deleteBond(getDevice().getAddress());
+        
+        // 缓冲一下，进行第二次尝试，此时将重新进行安全配对
+        delay(500); 
+        result = RemoteScales::clientConnect();
+    }
+
+    if (!result) {
+        RemoteScales::log("Final connection attempt failed.\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    // 执行协议握手
+    if (!performConnectionHandshake()) {
+        RemoteScales::log("Handshake failed. Cleaning up.\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    subscribeToNotifications();
+    RemoteScales::setWeight(0.f);
+    return true;
+}
+
+void TimemoreNewScales::disconnect() {
+    RemoteScales::clientCleanup();
+}
+
+bool TimemoreNewScales::isConnected() {
+    return RemoteScales::clientIsConnected();
+}
+
+void TimemoreNewScales::update() {
+    // 状态维护逻辑：如果在此周期发现断线，则触发重新连接
+    // connect() 内部自带了密钥冲突的重试容错机制
+    if (!isConnected()) {
+        RemoteScales::log("Device disconnected. Attempting to reconnect...\n");
+        delay(1000); // 延时缓冲，给物理设备一些反应时间
+        if (connect()) {
+            RemoteScales::log("Reconnected to Timemore Dot successfully.\n");
+        }
+    }
+}
+
+bool TimemoreNewScales::tare() {
+    if (!isConnected() || commandCharacteristic == nullptr) {
+        RemoteScales::log("Cannot tare, not connected or no command characteristic.\n");
+        return false;
+    }
+
+    // 根据官方规范构建去皮包: A5 5A 03 0D 00 00 + CRC
+    uint8_t packet[8] = { 
+        0xA5, 0x5A, 
+        0x03, // CTRL_CMD
+        0x0D, // TARE_ACTION
+        0x00, 0x00, 0x00, 0x00 
+    };
+    
+    uint16_t crc = calculateCRC16(packet, 6);
+    packet[6] = crc & 0xFF;         // 小端序存储 CRC 低字节
+    packet[7] = (crc >> 8) & 0xFF;  // 小端序存储 CRC 高字节
+
+    RemoteScales::log("Sending tare command...\n");
+    commandCharacteristic->writeValue(packet, sizeof(packet), false);
+    return true;
+}
+
+// -----------------------------------------------------------------------------------
+// ---------------------------------  PRIVATE  ---------------------------------------
+// -----------------------------------------------------------------------------------
+
+bool TimemoreNewScales::performConnectionHandshake() {
+    RemoteScales::log("Performing handshake...\n");
+
+    service = RemoteScales::clientGetService(TIMEMORE_NEW_SERVICE_UUID);
+    if (service == nullptr) {
+        RemoteScales::log("Failed to get Timemore Dot service.\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    notifyCharacteristic = service->getCharacteristic(TIMEMORE_NEW_NOTIFY_CHAR_UUID);
+    commandCharacteristic = service->getCharacteristic(TIMEMORE_NEW_COMMAND_CHAR_UUID);
+    
+    if (notifyCharacteristic == nullptr || commandCharacteristic == nullptr) {
+        RemoteScales::log("Failed to get notify or command characteristics.\n");
+        RemoteScales::clientCleanup();
+        return false;
+    }
+
+    // 开启设备端的数据通知描述符 (0x2902)
+    NimBLERemoteDescriptor* notifyDesc = notifyCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
+    if (notifyDesc != nullptr) {
+        uint8_t value[2] = { 0x01, 0x00 };
+        notifyDesc->writeValue(value, 2, true);
+    } else {
+        RemoteScales::log("Failed to find notification descriptor.\n");
+        return false;
+    }
+
+    // 发送官方 App 在连接成功后的 6 个初始化查询指令，以唤醒数据流
+    uint8_t initQueries[] = { 19, 8, 5, 2, 6, 12 };
+    for (int i = 0; i < 6; i++) {
+        sendQueryCommand(initQueries[i]);
+        delay(160); // 严格遵循官方规定的发包间隔
+    }
+    
+    RemoteScales::log("Handshake completed successfully.\n");
+    return true;
+}
+
+void TimemoreNewScales::sendQueryCommand(uint8_t queryType) {
+    if (commandCharacteristic == nullptr) return;
+    
+    // 查询帧格式: A5 5A 02 [type] 00 00 00 00
+    uint8_t payload[8] = { 
+        0xA5, 0x5A, 
+        0x02, // QUERY_CMD
+        queryType, 
+        0x00, 0x00, 0x00, 0x00 
+    };
+    commandCharacteristic->writeValue(payload, sizeof(payload), true);
+}
+
+void TimemoreNewScales::notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+    // 将底层接收到的字节数据压入滑动缓冲区
+    dataBuffer.insert(dataBuffer.end(), data, data + length);
+    
+    // 循环解析，直到缓冲区内没有完整的有效帧 (防止粘包)
+    while (decodeAndHandleNotification());
+}
+
+bool TimemoreNewScales::decodeAndHandleNotification() {
+    if (dataBuffer.size() < 2) return false;
+
+    // 寻找有效帧头: A5 5A
+    int headerIndex = -1;
+    for (size_t i = 0; i < dataBuffer.size() - 1; ++i) {
+        if (dataBuffer[i] == 0xA5 && dataBuffer[i+1] == 0x5A) {
+            headerIndex = i;
+            break;
+        }
+    }
+
+    // 没有找到帧头，清空垃圾数据并退出
+    if (headerIndex == -1) {
+        dataBuffer.clear(); 
+        return false;
+    }
+    
+    // 擦除帧头之前的所有无效字节
+    if (headerIndex > 0) {
+        dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + headerIndex); 
+    }
+
+    // 此时 dataBuffer 必定以 A5 5A 开头。检查是否包含完整的长度字段 (偏移量 4~5)
+    if (dataBuffer.size() < 6) return false;
+
+    // 读取 Data Payload 的长度 (大端序)
+    uint16_t payloadLen = (dataBuffer[4] << 8) | dataBuffer[5];
+    size_t fullLen = 6 + payloadLen + 2; // 帧头(2) + 类型(2) + 长度字段(2) + 载荷(N) + CRC(2)
+    
+    // 缓冲区数据尚不够一个完整的包，继续等待
+    if (dataBuffer.size() < fullLen) return false;
+
+    // 校验包类型 (0x01 0x01 = WEIGHT_DATA)
+    if (dataBuffer[2] == 0x01 && dataBuffer[3] == 0x01 && payloadLen >= 9) {
+        // 读取 32-bit 有符号大端序重量原始值 (位于偏移量 6)
+        int32_t rawWeight = (dataBuffer[6] << 24) | 
+                            (dataBuffer[7] << 16) | 
+                            (dataBuffer[8] <<  8) | 
+                            dataBuffer[9];
+        
+        // 转换为浮点数重量并推送到 Gaggiuino 框架
+        float weight = rawWeight / 10.0f;
+        RemoteScales::setWeight(weight);
+    }
+
+    // 核心逻辑：当前完整帧已处理完毕，将其从缓冲区彻底擦除
+    dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + fullLen);
+    
+    // 返回 true 以指示外部循环继续检查缓冲区是否还有下一个包
+    return dataBuffer.size() >= 6;
+}
+
+uint16_t TimemoreNewScales::calculateCRC16(const uint8_t* data, size_t length) {
+    // 官方算法：初始值 0，多项式 0xA001，LSB-first
+    uint16_t crc = 0x0000; 
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; j++) {
+            if ((crc & 0x0001) != 0) {
+                crc = (crc >> 1) ^ 0xA001; 
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    return crc;
+}
+
+void TimemoreNewScales::subscribeToNotifications() {
+    RemoteScales::log("Subscribing to notifications...\n");
+
+    auto callback = [this](NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
+        notifyCallback(characteristic, data, length, isNotify);
+    };
+
+    if (notifyCharacteristic->canNotify() || notifyCharacteristic->canIndicate()) {
+        notifyCharacteristic->subscribe(true, callback);
+        RemoteScales::log("Successfully subscribed to notify characteristic.\n");
+    } else {
+        RemoteScales::log("Notify characteristic cannot notify.\n");
+    }
+}

--- a/src/scales/timemore_new.cpp
+++ b/src/scales/timemore_new.cpp
@@ -1,7 +1,7 @@
 #include "timemore_new.h"
 #include "remote_scales_plugin_registry.h"
 
-// 使用完整的 128-bit UUID 以确保最高兼容性
+// Use full 128-bit UUIDs to ensure maximum compatibility
 const NimBLEUUID TIMEMORE_NEW_SERVICE_UUID("0000fff0-0000-1000-8000-00805f9b34fb");
 const NimBLEUUID TIMEMORE_NEW_NOTIFY_CHAR_UUID("0000fff1-0000-1000-8000-00805f9b34fb");
 const NimBLEUUID TIMEMORE_NEW_COMMAND_CHAR_UUID("0000fff2-0000-1000-8000-00805f9b34fb");
@@ -19,17 +19,17 @@ bool TimemoreNewScales::connect() {
 
     RemoteScales::log("Connecting to %s [%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
 
-    // 第一次连接尝试
+    // First connection attempt
     bool result = RemoteScales::clientConnect();
     
     if (!result) {
-        // 【智能容错】：连接失败极有可能是电子秤被重置，导致旧的配对密钥(Bond)失效
+        // [Smart Fault Tolerance]: Connection failure is highly likely due to the scale being reset, causing the old pairing key (Bond) to become invalid
         RemoteScales::log("Connection failed. Attempting to delete old bond and retry...\n");
         
-        // 精准删除这个特定 MAC 地址的本地配对记录
+        // Accurately delete the local pairing record for this specific MAC address
         NimBLEDevice::deleteBond(getDevice().getAddress());
         
-        // 缓冲一下，进行第二次尝试，此时将重新进行安全配对
+        // Buffer slightly and make a second attempt; secure pairing will be re-initiated at this time
         delay(500); 
         result = RemoteScales::clientConnect();
     }
@@ -40,7 +40,7 @@ bool TimemoreNewScales::connect() {
         return false;
     }
 
-    // 执行协议握手
+    // Execute protocol handshake
     if (!performConnectionHandshake()) {
         RemoteScales::log("Handshake failed. Cleaning up.\n");
         RemoteScales::clientCleanup();
@@ -61,12 +61,12 @@ bool TimemoreNewScales::isConnected() {
 }
 
 void TimemoreNewScales::update() {
-    // 状态维护逻辑：如果在此周期发现断线，则触发重新连接
+    // Status maintenance logic: If disconnection is detected in this cycle, trigger reconnection
     if (!isConnected()) {
-        // 使用静态变量记录上一次尝试重连的时间
+        // Use a static variable to record the time of the last reconnection attempt
         static uint32_t lastReconnectAttempt = 0;
         
-        // 智能节流：断线后，每隔 5 秒才进行一次重连尝试，而不是每毫秒都在死等
+        // Smart throttling: After disconnection, attempt to reconnect only once every 5 seconds, rather than busy-waiting every millisecond
         if (millis() - lastReconnectAttempt > 5000) {
             RemoteScales::log("Device disconnected. Attempting to reconnect...\n");
             
@@ -76,7 +76,7 @@ void TimemoreNewScales::update() {
                 RemoteScales::log("Reconnect failed. Will retry in 5 seconds.\n");
             }
             
-            // 更新最后尝试的时间
+            // Update the time of the last attempt
             lastReconnectAttempt = millis();
         }
     }
@@ -88,7 +88,7 @@ bool TimemoreNewScales::tare() {
         return false;
     }
 
-    // 根据官方规范构建去皮包: A5 5A 03 0D 00 00 + CRC
+    // Build tare packet according to official specifications: A5 5A 03 0D 00 00 + CRC
     uint8_t packet[8] = { 
         0xA5, 0x5A, 
         0x03, // CTRL_CMD
@@ -97,8 +97,8 @@ bool TimemoreNewScales::tare() {
     };
     
     uint16_t crc = calculateCRC16(packet, 6);
-    packet[6] = crc & 0xFF;         // 小端序存储 CRC 低字节
-    packet[7] = (crc >> 8) & 0xFF;  // 小端序存储 CRC 高字节
+    packet[6] = crc & 0xFF;         // Store CRC low byte in little-endian format
+    packet[7] = (crc >> 8) & 0xFF;  // Store CRC high byte in little-endian format
 
     RemoteScales::log("Sending tare command...\n");
     commandCharacteristic->writeValue(packet, sizeof(packet), false);
@@ -128,7 +128,7 @@ bool TimemoreNewScales::performConnectionHandshake() {
         return false;
     }
 
-    // 开启设备端的数据通知描述符 (0x2902)
+    // Enable the data notification descriptor (0x2902) on the device
     NimBLERemoteDescriptor* notifyDesc = notifyCharacteristic->getDescriptor(NimBLEUUID((uint16_t)0x2902));
     if (notifyDesc != nullptr) {
         uint8_t value[2] = { 0x01, 0x00 };
@@ -138,11 +138,11 @@ bool TimemoreNewScales::performConnectionHandshake() {
         return false;
     }
 
-    // 发送官方 App 在连接成功后的 6 个初始化查询指令，以唤醒数据流
+    // Send the 6 initialization query commands used by the official App after successful connection to wake up the data stream
     uint8_t initQueries[] = { 19, 8, 5, 2, 6, 12 };
     for (int i = 0; i < 6; i++) {
         sendQueryCommand(initQueries[i]);
-        delay(160); // 严格遵循官方规定的发包间隔
+        delay(160); // Strictly follow the packet sending interval specified by official guidelines
     }
     
     RemoteScales::log("Handshake completed successfully.\n");
@@ -152,7 +152,7 @@ bool TimemoreNewScales::performConnectionHandshake() {
 void TimemoreNewScales::sendQueryCommand(uint8_t queryType) {
     if (commandCharacteristic == nullptr) return;
     
-    // 查询帧格式: A5 5A 02 [type] 00 00 00 00
+    // Query frame format: A5 5A 02 [type] 00 00 00 00
     uint8_t payload[8] = { 
         0xA5, 0x5A, 
         0x02, // QUERY_CMD
@@ -163,17 +163,17 @@ void TimemoreNewScales::sendQueryCommand(uint8_t queryType) {
 }
 
 void TimemoreNewScales::notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify) {
-    // 将底层接收到的字节数据压入滑动缓冲区
+    // Push the byte data received from the lower layer into the sliding buffer
     dataBuffer.insert(dataBuffer.end(), data, data + length);
     
-    // 循环解析，直到缓冲区内没有完整的有效帧 (防止粘包)
+    // Parse in a loop until there are no complete valid frames in the buffer (preventing packet sticking)
     while (decodeAndHandleNotification());
 }
 
 bool TimemoreNewScales::decodeAndHandleNotification() {
     if (dataBuffer.size() < 2) return false;
 
-    // 寻找有效帧头: A5 5A
+    // Look for valid frame header: A5 5A
     int headerIndex = -1;
     for (size_t i = 0; i < dataBuffer.size() - 1; ++i) {
         if (dataBuffer[i] == 0xA5 && dataBuffer[i+1] == 0x5A) {
@@ -182,49 +182,49 @@ bool TimemoreNewScales::decodeAndHandleNotification() {
         }
     }
 
-    // 没有找到帧头，清空垃圾数据并退出
+    // No frame header found, clear garbage data and exit
     if (headerIndex == -1) {
         dataBuffer.clear(); 
         return false;
     }
     
-    // 擦除帧头之前的所有无效字节
+    // Erase all invalid bytes before the frame header
     if (headerIndex > 0) {
         dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + headerIndex); 
     }
 
-    // 此时 dataBuffer 必定以 A5 5A 开头。检查是否包含完整的长度字段 (偏移量 4~5)
+    // At this point, dataBuffer must start with A5 5A. Check if it contains the complete length field (offset 4~5)
     if (dataBuffer.size() < 6) return false;
 
-    // 读取 Data Payload 的长度 (大端序)
+    // Read the length of the Data Payload (Big-Endian)
     uint16_t payloadLen = (dataBuffer[4] << 8) | dataBuffer[5];
-    size_t fullLen = 6 + payloadLen + 2; // 帧头(2) + 类型(2) + 长度字段(2) + 载荷(N) + CRC(2)
+    size_t fullLen = 6 + payloadLen + 2; // Header(2) + Type(2) + Length field(2) + Payload(N) + CRC(2)
     
-    // 缓冲区数据尚不够一个完整的包，继续等待
+    // The buffer data is not yet enough for a complete packet, continue waiting
     if (dataBuffer.size() < fullLen) return false;
 
-    // 校验包类型 (0x01 0x01 = WEIGHT_DATA)
+    // Verify packet type (0x01 0x01 = WEIGHT_DATA)
     if (dataBuffer[2] == 0x01 && dataBuffer[3] == 0x01 && payloadLen >= 9) {
-        // 读取 32-bit 有符号大端序重量原始值 (位于偏移量 6)
+        // Read the 32-bit signed big-endian raw weight value (located at offset 6)
         int32_t rawWeight = (dataBuffer[6] << 24) | 
                             (dataBuffer[7] << 16) | 
                             (dataBuffer[8] <<  8) | 
                             dataBuffer[9];
         
-        // 转换为浮点数重量并推送到 Gaggiuino 框架
+        // Convert to floating-point weight and push to the Gaggiuino framework
         float weight = rawWeight / 10.0f;
         RemoteScales::setWeight(weight);
     }
 
-    // 核心逻辑：当前完整帧已处理完毕，将其从缓冲区彻底擦除
+    // Core logic: The current complete frame has been processed, completely erase it from the buffer
     dataBuffer.erase(dataBuffer.begin(), dataBuffer.begin() + fullLen);
     
-    // 返回 true 以指示外部循环继续检查缓冲区是否还有下一个包
+    // Return true to indicate that the outer loop should continue checking the buffer for the next packet
     return dataBuffer.size() >= 6;
 }
 
 uint16_t TimemoreNewScales::calculateCRC16(const uint8_t* data, size_t length) {
-    // 官方算法：初始值 0，多项式 0xA001，LSB-first
+    // Official algorithm: Initial value 0, polynomial 0xA001, LSB-first
     uint16_t crc = 0x0000; 
     for (size_t i = 0; i < length; i++) {
         crc ^= data[i];
@@ -252,4 +252,6 @@ void TimemoreNewScales::subscribeToNotifications() {
     } else {
         RemoteScales::log("Notify characteristic cannot notify.\n");
     }
+}
+
 }

--- a/src/scales/timemore_new.h
+++ b/src/scales/timemore_new.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <memory>
 
-// 定义 Timemore Dot (Ble2025) 的消息类型
+// Define message types for Timemore Dot (Ble2025)
 enum class TimemoreNewMessageType : uint8_t {
     WEIGHT_DATA = 0x01,
     QUERY_CMD   = 0x02,
@@ -54,26 +54,21 @@ public:
 
 private:
     static bool handles(const DiscoveredDevice& device) {
-    const std::string& deviceName = device.getName();
-    const std::string& mfgData = device.getManufacturerData();
-    
-    std::string mfgHex = "";
-    for (size_t i = 0; i < mfgData.length(); i++) {
-        char hex[4];
-        snprintf(hex, sizeof(hex), "%02X ", (uint8_t)mfgData[i]);
-        mfgHex += hex;
+        const std::string& deviceName = device.getName();
+        const std::string& mfgData = device.getManufacturerData();
+        
+        std::string mfgHex = "";
+        for (size_t i = 0; i < mfgData.length(); i++) {
+            char hex[4];
+            snprintf(hex, sizeof(hex), "%02X ", (uint8_t)mfgData[i]);
+            mfgHex += hex;
+        }
+
+        // General matching condition 1: Name matches (use 'find' to prevent issues with leading spaces)
+        if (!deviceName.empty() && deviceName.find("TIMEMORE_Dot") != std::string::npos) {
+            return true;
+        }
+
+        return false;
     }
-
-    Serial.printf("[SCAN] Name: '%s', MAC: %s, MfgData: %s\n", 
-                  deviceName.empty() ? "UNKNOWN" : deviceName.c_str(), 
-                  device.getAddress().toString().c_str(),
-                  mfgHex.empty() ? "NONE" : mfgHex.c_str());
-
-    // 通用适配条件 1：名字能匹配上 (防止有前导空格，改用 find)
-    if (!deviceName.empty() && deviceName.find("TIMEMORE_Dot") != std::string::npos) {
-        return true;
-    }
-
-    return false;
-}
 };

--- a/src/scales/timemore_new.h
+++ b/src/scales/timemore_new.h
@@ -1,0 +1,79 @@
+#pragma once
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+#include <NimBLEDevice.h>
+#include <vector>
+#include <memory>
+
+// 定义 Timemore Dot (Ble2025) 的消息类型
+enum class TimemoreNewMessageType : uint8_t {
+    WEIGHT_DATA = 0x01,
+    QUERY_CMD   = 0x02,
+    CTRL_CMD    = 0x03,
+    TARE_ACTION = 0x0D
+};
+
+class TimemoreNewScales : public RemoteScales {
+public:
+    TimemoreNewScales(const DiscoveredDevice& device);
+
+    bool connect() override;
+    void disconnect() override;
+    bool isConnected() override;
+    void update() override;
+    bool tare() override;
+
+private:
+    NimBLERemoteService* service = nullptr;
+    NimBLERemoteCharacteristic* notifyCharacteristic = nullptr;
+    NimBLERemoteCharacteristic* commandCharacteristic = nullptr;
+
+    std::vector<uint8_t> dataBuffer;
+    bool markedForReconnection = false;
+
+    bool performConnectionHandshake();
+    void sendQueryCommand(uint8_t queryType);
+    void notifyCallback(NimBLERemoteCharacteristic* characteristic, uint8_t* data, size_t length, bool isNotify);
+    bool decodeAndHandleNotification();
+    uint16_t calculateCRC16(const uint8_t* data, size_t length);
+    void subscribeToNotifications();
+};
+
+class TimemoreNewScalesPlugin {
+public:
+    static void apply() {
+        RemoteScalesPlugin plugin = RemoteScalesPlugin{
+            .id = "plugin-timemore-dot",
+            .handles = [](const DiscoveredDevice& device) { return TimemoreNewScalesPlugin::handles(device); },
+            .initialise = [](const DiscoveredDevice& device) -> std::unique_ptr<RemoteScales> {
+                return std::make_unique<TimemoreNewScales>(device);
+            },
+        };
+        RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+    }
+
+private:
+    static bool handles(const DiscoveredDevice& device) {
+    const std::string& deviceName = device.getName();
+    const std::string& mfgData = device.getManufacturerData();
+    
+    std::string mfgHex = "";
+    for (size_t i = 0; i < mfgData.length(); i++) {
+        char hex[4];
+        snprintf(hex, sizeof(hex), "%02X ", (uint8_t)mfgData[i]);
+        mfgHex += hex;
+    }
+
+    Serial.printf("[SCAN] Name: '%s', MAC: %s, MfgData: %s\n", 
+                  deviceName.empty() ? "UNKNOWN" : deviceName.c_str(), 
+                  device.getAddress().toString().c_str(),
+                  mfgHex.empty() ? "NONE" : mfgHex.c_str());
+
+    // 通用适配条件 1：名字能匹配上 (防止有前导空格，改用 find)
+    if (!deviceName.empty() && deviceName.find("TIMEMORE_Dot") != std::string::npos) {
+        return true;
+    }
+
+    return false;
+}
+};


### PR DESCRIPTION
Since the Timemore Black Mirror Dot shares the product line with the Black Mirror Duo but has a completely different communication protocol, I decided to implement it as a separate codebase.
<img width="1440" height="1920" alt="IMG_5941" src="https://github.com/user-attachments/assets/66bc989b-a099-4f6b-b8d1-eab0ce002603" />
<img width="1440" height="1920" alt="IMG_5942" src="https://github.com/user-attachments/assets/60d754ec-b1b8-488d-8cde-dee5b6fd48ec" />

