### PR TITLE
Add timer commands for Bookoo scales

### DIFF
--- a/src/remote_scales.h
+++ b/src/remote_scales.h
@@ -39,6 +39,10 @@ public:
   virtual bool connect() = 0;
   virtual void disconnect() = 0;
   virtual void update() = 0;
+  virtual bool startTimer() { return false; }
+  virtual bool stopTimer() { return false; }
+  virtual bool resetTimer() { return false; }
+  virtual bool tareAndStartTimer() { return false; }
 
   ~RemoteScales() { clientCleanup(); }
 protected:

--- a/src/scales/bookoo.cpp
+++ b/src/scales/bookoo.cpp
@@ -65,8 +65,40 @@ bool BookooScales::tare() {
   sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
 
   return true;
-};
+}
 
+bool BookooScales::startTimer() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Start timer sent\n");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x04, 0x00, 0x00, 0x0a };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+}
+ 
+bool BookooScales::stopTimer() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Stop timer sent\n");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x05, 0x00, 0x00, 0x0d };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+}
+ 
+bool BookooScales::resetTimer() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Reset timer sent\n");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x06, 0x00, 0x00, 0x0c };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+}
+ 
+bool BookooScales::tareAndStartTimer() {
+  if (!isConnected()) return false;
+  RemoteScales::log("Tare and start timer sent\n");
+  uint8_t payload[6] = { 0x03, 0x0a, 0x07, 0x00, 0x00, 0x00 };
+  sendMessage(BookooMessageType::SYSTEM, payload, sizeof(payload));
+  return true;
+}
+ 
 //-----------------------------------------------------------------------------------/
 //---------------------------       PRIVATE       -----------------------------------/
 //-----------------------------------------------------------------------------------/

--- a/src/scales/bookoo.h
+++ b/src/scales/bookoo.h
@@ -21,6 +21,10 @@ public:
   void disconnect() override;
   bool isConnected() override;
   bool tare() override;
+  bool startTimer() override;
+  bool stopTimer() override;
+  bool resetTimer() override;
+  bool tareAndStartTimer() override;
 
 private:
   std::string weightUnits;


### PR DESCRIPTION
This PR adds support for the timer commands defined in the Bookoo Scale protocol spec: https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md

Changes:
- Added startTimer(), stopTimer(), resetTimer(), and tareAndStartTimer() to BookooScales
- Added the same four methods as non-pure virtual methods with default no-op implementations 
  to RemoteScales base class, so other scale implementations can add timer support as-needed 
  without breaking existing scales

The tareAndStartTimer() command is the recommended way to start a shot according to the 
Bookoo protocol spec, making this particularly useful for espresso shot workflow integration.

All existing functionality is unchanged.

Note: Developed with assistance from Claude (Anthropic). Claude reviewed the BooKoo Mini and Ultra protocol specs, identified the three files that needed to be updated (bookoo.cpp, bookoo.h, remote_scales.h), implemented the new methods following the existing boilerplate patterns in the codebase, and recommended adding the methods as non-pure virtuals to the base class so other scale implementations can add timer support without breaking existing ones.