### PR TITLE
Refactor Timemore Dot plugin: Enhance connection stability, fix memory pollution, and align bonding logic

### DIFF
--- a/src/scales/timemore_new.cpp
+++ b/src/scales/timemore_new.cpp
@@ -52,7 +52,7 @@ bool TimemoreNewScales::connect() {
         return false;
     }
 
-    subscribeToNotifications();
+    //subscribeToNotifications();
     RemoteScales::setWeight(0.f);
     return true;
 }
@@ -68,8 +68,12 @@ bool TimemoreNewScales::isConnected() {
 void TimemoreNewScales::update() {
     // Status maintenance logic: If disconnection is detected in this cycle, trigger reconnection
     if (!isConnected()) {
-        // Use a static variable to record the time of the last reconnection attempt
-        static uint32_t lastReconnectAttempt = 0;
+        
+        // [Fix] State machine: Mark for reconnection and reset timer to trigger immediately
+        if (!markedForReconnection) {
+            markedForReconnection = true;
+            lastReconnectAttempt = millis() - 5000; 
+        }
         
         // Smart throttling: After disconnection, attempt to reconnect only once every 5 seconds, rather than busy-waiting every millisecond
         if (millis() - lastReconnectAttempt > 5000) {
@@ -77,6 +81,7 @@ void TimemoreNewScales::update() {
             
             if (connect()) {
                 RemoteScales::log("Reconnected to Timemore Dot successfully.\n");
+                markedForReconnection = false; // Clear the disconnection flag upon success
             } else {
                 RemoteScales::log("Reconnect failed. Will retry in 5 seconds.\n");
             }
@@ -84,6 +89,9 @@ void TimemoreNewScales::update() {
             // Update the time of the last attempt
             lastReconnectAttempt = millis();
         }
+     } else {
+        // Ensure the flag is cleared when normally connected
+        markedForReconnection = false;  
     }
 }
 
@@ -142,6 +150,9 @@ bool TimemoreNewScales::performConnectionHandshake() {
         RemoteScales::log("Failed to find notification descriptor.\n");
         return false;
     }
+    // [Fix] Subscribe to notifications BEFORE sending initialization queries
+    // This hooks up the listener to properly ingest responsive handshake data frames
+    subscribeToNotifications();
 
     // Send the 6 initialization query commands used by the official App after successful connection to wake up the data stream
     uint8_t initQueries[] = { 19, 8, 5, 2, 6, 12 };

--- a/src/scales/timemore_new.cpp
+++ b/src/scales/timemore_new.cpp
@@ -19,6 +19,11 @@ bool TimemoreNewScales::connect() {
 
     RemoteScales::log("Connecting to %s [%s]\n", RemoteScales::getDeviceName().c_str(), RemoteScales::getDeviceAddress().c_str());
 
+    // [Fix] Dynamically enable secure bonding parameters to fulfill Timemore Dot requirements
+    NimBLEDevice::setSecurityAuth(true, false, true);
+    // This perfectly simulates the 'createBond()' behavior found in the official Android app
+    NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
+
     // First connection attempt
     bool result = RemoteScales::clientConnect();
     

--- a/src/scales/timemore_new.h
+++ b/src/scales/timemore_new.h
@@ -29,6 +29,8 @@ private:
     NimBLERemoteCharacteristic* commandCharacteristic = nullptr;
 
     std::vector<uint8_t> dataBuffer;
+    // [Fix] Class member timer isolates instance lifecycles and prevents memory pollution
+    uint32_t lastReconnectAttempt = 0; 
     bool markedForReconnection = false;
 
     bool performConnectionHandshake();


### PR DESCRIPTION
Description:
This PR introduces critical stability improvements and architectural fixes to the timemore_new (Timemore Dot) scales plugin, based on reverse-engineering the official Timemore Android App's BLE logic.
Key Changes:
	1.Fixed Notification Subscription Timing (Prevent Packet Loss): Moved subscribeToNotifications() to execute before dispatching the 6 initialization query commands. This perfectly aligns with the official app's onNotifySuccess behavior and ensures no critical early handshake packets are dropped during the 160ms query intervals.
	2.Resolved Instance Memory Pollution (Static Variable Trap): Converted the local static uint32_t lastReconnectAttempt in the update() loop into a private class member. This guarantees that if the RemoteScalesFactory deletes and recreates the scale instance, stale timestamps won't persist and deadlock the new connection attempt.
	3.Aligned Security/Bonding Handshake: Explicitly invoked NimBLEDevice::setSecurityAuth(true, false, true)and setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT) during connect(). This mimics the official app's explicit createBond() request (transitioning from BOND_NONE to BOND_BONDED), preventing the scale from spontaneously terminating the connection due to missing "Just Works" pairing parameters.