### PR TITLE
Add IKAPE Smart Coffee Scale (APP_V2 Pro) BLE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This allows for easy extention of the library for more bluetooth enabled scales.
 * [CFS-9002/Eureka Precisa](https://www.aliexpress.com/item/1005008898452251.html) - [Tested]
 * [Felicita Arc](http://www.felicitacoffee.com/PRODUCT_1/10.html) - [Tested]
 * [INSMART 863A](https://www.amazon.com/INSMART-Coffee-Scale-with-Timer/dp/B0FRMQFNJ4) - [Tested]
+* [IKAPE Smart Coffee Scale (APP_V2 Pro)](https://ikapestore.com/products/ikape-smart-electronic-coffee-scale-with-bluetooth-app) - [Tested]
 * [Solobarista](https://item.taobao.com/item.htm?id=848706090408&skuId=5805800327323&spm=a21xtw.29178619.0.0) - [Tested]
 * [Timemore Black Mirror DUO](https://www.timemore.com/collections/coffee-scale/products/timemore-coffee-scale-black-mirror-duo) - [Tested]
 * [Timemore Black Mirror Dot](https://e.tb.cn/h.RaauU1uixK6rBHE?tk=NKEx5psOlHb) - [Tested]

--- a/src/scales/ikape.cpp
+++ b/src/scales/ikape.cpp
@@ -1,0 +1,116 @@
+#include "ikape.h"
+#include "remote_scales_plugin_registry.h"
+
+// IK-Cafe A01. Confirmed from live capture:
+//   service FFF0, notify FFF1, write FFF2 (write / write-no-response).
+//   Streams weight on subscribe - no wake command required.
+static const NimBLEUUID SERVICE_UUID("FFF0");
+static const NimBLEUUID WEIGHT_CHAR_UUID("FFF1");   // notify
+static const NimBLEUUID CMD_CHAR_UUID("FFF2");      // write (tare)
+
+IkapeScales::IkapeScales(const DiscoveredDevice& device)
+  : RemoteScales(device) {}
+
+bool IkapeScales::connect() {
+  if (clientIsConnected()) { log("Already connected\n"); return true; }
+  log("Connecting to %s[%s]\n", getDeviceName().c_str(), getDeviceAddress().c_str());
+  if (!clientConnect()) { clientCleanup(); return false; }
+  if (!performConnectionHandshake()) return false;
+  if (!subscribeToNotifications()) return false;
+
+  // Force grams (unit code 05) so weight is unambiguous regardless of how the
+  // user left the scale. Same A7 00 01 02 04 [code] .. 7A grammar as tare;
+  // confirmed live that writing this sets the display/unit to grams. The BLE
+  // value is decigrams in every unit anyway, so this is belt-and-suspenders.
+  static const uint8_t setGrams[] = { 0xA7, 0x00, 0x01, 0x02, 0x04, 0x05, 0x0C, 0x7A };
+  cmdCharacteristic->writeValue(const_cast<uint8_t*>(setGrams), sizeof(setGrams), false);
+
+  setWeight(0.f);
+  return true;
+}
+
+void IkapeScales::disconnect() { clientCleanup(); }
+bool IkapeScales::isConnected() { return clientIsConnected(); }
+
+void IkapeScales::update() {
+  if (markedForReconnection) {
+    log("Reconnecting\n");
+    clientCleanup();
+    if (connect()) markedForReconnection = false;
+  } else {
+    verifyConnected();
+  }
+}
+
+bool IkapeScales::tare() {
+  if (!verifyConnected()) return false;
+  // Confirmed tare command (write to FFF2, zeroes the scale). Same frame the
+  // scale emits on a physical tare press; verified live over BLE.
+  // Format A7 00 01 [type=02] [sub=02] [param=01] [CK] 7A, CK=sum(bytes[2..5])&0xFF.
+  static const uint8_t tareCmd[] = { 0xA7, 0x00, 0x01, 0x02, 0x02, 0x01, 0x06, 0x7A };
+  cmdCharacteristic->writeValue(const_cast<uint8_t*>(tareCmd), sizeof(tareCmd), false);
+  return true;
+}
+
+bool IkapeScales::performConnectionHandshake() {
+  service = clientGetService(SERVICE_UUID);
+  if (service == nullptr) { log("Service not found\n"); clientCleanup(); return false; }
+
+  service->getCharacteristics(true);
+  weightCharacteristic = service->getCharacteristic(WEIGHT_CHAR_UUID);
+  cmdCharacteristic    = service->getCharacteristic(CMD_CHAR_UUID);
+  if (weightCharacteristic == nullptr || cmdCharacteristic == nullptr) {
+    log("Required characteristics not found\n"); clientCleanup(); return false;
+  }
+  weightCharacteristic->getDescriptors(true);
+  cmdCharacteristic->getDescriptors(true);
+  return true;
+}
+
+bool IkapeScales::subscribeToNotifications() {
+  if (!weightCharacteristic->canNotify()) {
+    log("Weight characteristic cannot notify\n"); clientCleanup(); return false;
+  }
+  auto cb = [this](NimBLERemoteCharacteristic* c, uint8_t* d, size_t len, bool n) {
+    notifyCallback(c, d, len, n);
+  };
+  if (!weightCharacteristic->subscribe(true, cb, true)) {
+    log("Failed to subscribe\n"); clientCleanup(); return false;
+  }
+  return true;
+}
+
+void IkapeScales::notifyCallback(NimBLERemoteCharacteristic* characteristic,
+                                  uint8_t* data, size_t length, bool isNotify) {
+  float w = decodeWeight(data, length);
+  if (w > -100000.f) setWeight(w);
+}
+
+// 20-byte weight frame: A7 00 01 0E 13 [b5] [b6] [b7] 00 [HH LL] [md] 00*5 [s] [CK] 7A
+//   weight = UNSIGNED big-endian uint16 at [9:10], tenths of a gram.
+//   CK (byte 18) = sum(bytes[2..17]) & 0xFF. Header 0xA7, footer 0x7A, type[3]=0x0E.
+//   bytes[6],[7],[11] are mode/status (weigh vs espresso/timer); bytes[16:17] is a
+//   secondary value (flow/rate) present in espresso mode. None affect the weight.
+//   Confirmed against live capture across all modes. Standard weigh-mode anchors:
+//   00 00 -> 0.0 g, 04 B3 -> 120.3 g.
+float IkapeScales::decodeWeight(const uint8_t* data, size_t length) {
+  if (length != 20 || data[0] != 0xA7 || data[3] != 0x0E || data[19] != 0x7A)
+    return -100001.f;                          // not a weight frame
+  uint8_t sum = 0;
+  for (size_t i = 2; i <= 17; ++i) sum += data[i];
+  if (sum != data[18]) return -100001.f;       // bad checksum
+
+  // Signed int16: the scale floors negatives at 0x0000 on the BLE stream (its
+  // display shows them; FFF1 does not - verified with tare+remove in BOTH weigh
+  // (md=01) and brew (md=02) modes). Signed is byte-identical to unsigned for
+  // everything this scale sends (all << the 3276.7 g crossover), and defensively
+  // decodes a real two's-complement negative instead of spiking to ~6553 g.
+  int16_t raw = (int16_t)(((uint16_t)data[9] << 8) | data[10]);   // big-endian
+  return raw / 10.0f;
+}
+
+bool IkapeScales::verifyConnected() {
+  if (markedForReconnection) return false;
+  if (!isConnected()) { markedForReconnection = true; return false; }
+  return true;
+}

--- a/src/scales/ikape.h
+++ b/src/scales/ikape.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "remote_scales.h"
+#include "remote_scales_plugin_registry.h"
+
+// IK-Cafe A01 (and likely other "IK-Cafe ..." rebrands).
+//
+// NOTE: This device is currently also captured by the Precisa plugin's
+// manufacturer-data heuristic (mfr[0]==0xFF && mfr[1]==0xFF && mfr.back()==firstMacByte).
+// Because plugin selection is first-match-wins in registration order, this
+// plugin must be registered BEFORE PrecisaScalesPlugin::apply(), otherwise
+// Precisa will claim the device and parse it with the wrong protocol.
+
+class IkapeScales : public RemoteScales {
+public:
+  IkapeScales(const DiscoveredDevice& device);
+  virtual ~IkapeScales() = default;
+
+  bool connect() override;
+  void disconnect() override;
+  bool isConnected() override;
+  void update() override;
+  bool tare() override;
+
+private:
+  NimBLERemoteService*        service             = nullptr;
+  NimBLERemoteCharacteristic* weightCharacteristic = nullptr; // notify
+  NimBLERemoteCharacteristic* cmdCharacteristic    = nullptr; // write (tare / wake)
+
+  bool markedForReconnection = false;
+
+  bool performConnectionHandshake();
+  bool subscribeToNotifications();
+  bool verifyConnected();
+
+  void notifyCallback(NimBLERemoteCharacteristic* characteristic,
+                      uint8_t* data, size_t length, bool isNotify);
+
+  // Returns weight in grams, or a sentinel < -100000.f if the packet
+  // is not a weight frame (so the caller can ignore it).
+  float decodeWeight(const uint8_t* data, size_t length);
+};
+
+class IkapeScalesPlugin {
+public:
+  static void apply() {
+    RemoteScalesPlugin plugin = RemoteScalesPlugin{
+      .id = "plugin-ikape",
+      .handles = [](const DiscoveredDevice& device) {
+        return IkapeScalesPlugin::handles(device);
+      },
+      .initialise = [](const DiscoveredDevice& device)
+          -> std::unique_ptr<RemoteScales> {
+        return std::make_unique<IkapeScales>(device);
+      },
+    };
+    RemoteScalesPluginRegistry::getInstance()->registerPlugin(plugin);
+  }
+
+private:
+  static bool handles(const DiscoveredDevice& device) {
+    const std::string& name = device.getName();
+    // Prefix match so we claim it deterministically instead of relying on
+    // Precisa's generic manufacturer-data heuristic. Confirm the exact
+    // advertised prefix from your sniff ("IK-Cafe" per the settings screen).
+    return !name.empty() && name.rfind("IK-Cafe", 0) == 0;
+  }
+};


### PR DESCRIPTION
# Add IKAPE Smart Coffee Scale (APP_V2 Pro) BLE support

Adds support for the IKAPE Smart Electronic Coffee Scale with Bluetooth (APP_V2 Pro).
It advertises over BLE as `IK-Cafe A01-Fxxx` on the FFF0 service, so the plugin's
`handles()` matches the `IK-Cafe` name prefix (the advertised name differs from the
marketing name - see note below). Weight and tare both work.

## Why this is needed

Right now the A01 gets claimed by the Precisa plugin through its manufacturer-data
heuristic (`mfr[0]==0xFF && mfr[1]==0xFF && mfr.back()==firstMacByte`), so it
appears in the scanner and connects, but Precisa's parser expects a different
frame and no weight ever arrives. This plugin adds the correct protocol and a
name-prefix match so the A01 is handled properly.

## Note on naming

Marketing name: IKAPE Smart Electronic Coffee Scale with Bluetooth (APP_V2 Pro).
BLE advertised name: `IK-Cafe A01-Fxxx`. The `handles()` filter matches the
advertised `IK-Cafe` prefix, not the marketing name.

## Protocol (reverse-engineered and verified)

- Service `FFF0`, notify `FFF1`, write `FFF2`. Streams on subscribe, no wake needed.
- Weight frame, 20 bytes:
  `A7 00 01 0E 13 [b5] [b6] [b7] 00 [HH LL] [md] 00 00 [t] 00 [S16] [CK] 7A`
  - weight = big-endian int16 at bytes[9:10], tenths of a gram
  - `CK` (byte 18) = `sum(bytes[2..17]) & 0xFF`; header `0xA7`, footer `0x7A`, type[3]=`0x0E`
  - byte[6] = display unit (05 = grams), byte[11] = mode, byte[14] = brew-mode
    timer seconds, bytes[16:17] = a secondary (flow/rate) field. None affect weight.
- Tare command (write to FFF2): `A7 00 01 02 02 01 06 7A`
- The plugin also writes `A7 00 01 02 04 05 0C 7A` on connect to force grams,
  so readings are correct regardless of the unit the user left the scale in.
- Negatives are not transmitted; the display shows them but FFF1 floors at 0.
  Decode is signed int16 anyway (identical to unsigned across the scale's range,
  and safe against any future variant that does send a negative).

## Testing

Validated two ways against a real A01:
1. Protocol capture over BLE (Python/bleak) with known masses.
2. On-hardware, flashing this exact plugin to an ESP32-WROOM-32 running
   esp-arduino-ble-scales directly (not Gaggiuino), reading over serial.

On-hardware results (two independent known masses, each exact):
- 15 g weight -> steady `15.00 g`
- 19 g weight -> steady `19.00 g` (one 18.90 sample; normal 0.1 g dither)
- tare -> reading drops to `0.00 g` with weight still on the pan (verified repeatedly)

Frame -> grams samples (real captured frames):
- `A7 00 01 0E 13 02 05 02 00 00 00 01 ... 2C 7A`  -> 0.0 g
- `A7 00 01 0E 13 02 05 02 00 00 96 01 ... C2 7A`  -> 15.0 g
- `A7 00 01 0E 13 02 05 02 00 04 B3 01 ... E3 7A`  -> 120.3 g

## Note for merging: registration order

Because plugin selection is first-match-wins, this plugin must be registered
BEFORE `PrecisaScalesPlugin::apply()`, otherwise Precisa's manufacturer-data
heuristic still claims the A01 and parses it wrong. Alternatively, tighten the
Precisa heuristic to exclude this device. The Ikape `handles()` uses an
`IK-Cafe` name prefix, so ordering is the only change needed.

<details><summary>ESP32 serial log (15 g + 19 g + tare)</summary>
<pre>
# ESP32-WROOM-32 running esp-arduino-ble-scales (this PR's ikape plugin) directly.
# Read over serial @115200. Masses: nominal 15 g and 19 g. Plus tare via 't'.
# Annotations added as "# &lt;--"; everything else is verbatim device output.
=== IK-Cafe scale test harness ===
Scanning for supported scales...
Found: IK-Cafe A01-F391 [f8:8f:c8:f1:3b:ee]                 # &lt;-- discovery + name match
Scale[IK-Cafe A01-F391] Connecting to IK-Cafe A01-F391[f8:8f:c8:f1:3b:ee]
Scale[IK-Cafe A01-F391] Connecting to BLE client
WEIGHT: 0.00 g
Connected.                                                  # &lt;-- connected, subscribed, grams forced
getWeight(): 0.00 g  connected=1
WEIGHT: 7.00 g
WEIGHT: 12.30 g
WEIGHT: 15.80 g                                             # &lt;-- 15 g mass placed (settling)
WEIGHT: 15.00 g                                             # &lt;-- 15 g, steady
getWeight(): 15.00 g  connected=1
getWeight(): 15.00 g  connected=1
getWeight(): 15.00 g  connected=1
getWeight(): 15.00 g  connected=1
getWeight(): 15.00 g  connected=1
getWeight(): 15.00 g  connected=1
WEIGHT: 9.00 g
WEIGHT: 1.20 g                                              # &lt;-- removed
WEIGHT: 0.00 g
getWeight(): 0.00 g  connected=1
WEIGHT: 7.60 g
WEIGHT: 16.40 g
WEIGHT: 19.00 g                                             # &lt;-- 19 g mass placed
WEIGHT: 18.90 g                                             # &lt;-- 0.1 g dither
WEIGHT: 19.00 g                                             # &lt;-- steady
getWeight(): 19.00 g  connected=1
getWeight(): 19.00 g  connected=1
getWeight(): 19.00 g  connected=1
getWeight(): 19.00 g  connected=1
getWeight(): 19.00 g  connected=1
WEIGHT: 21.10 g
WEIGHT: 17.20 g                                             # &lt;-- removed
WEIGHT: 4.50 g
WEIGHT: 0.00 g
WEIGHT: 15.30 g
WEIGHT: 15.00 g                                             # &lt;-- 15 g back on
getWeight(): 15.00 g  connected=1
Tare sent.                                                  # &lt;-- typed 't'
WEIGHT: 0.00 g                                              # &lt;-- zeroed with mass still on pan
getWeight(): 0.00 g  connected=1
WEIGHT: 4.90 g
WEIGHT: 15.00 g
WEIGHT: 14.90 g
WEIGHT: 3.90 g
getWeight(): 3.90 g  connected=1
Tare sent.                                                  # &lt;-- typed 't'
WEIGHT: 0.00 g                                              # &lt;-- zeroed again
getWeight(): 0.00 g  connected=1
</pre>
</details>