### PR TITLE
IKAPE A01: write-with-response for tare

### DIFF
--- a/src/scales/ikape.cpp
+++ b/src/scales/ikape.cpp
@@ -48,7 +48,10 @@ bool IkapeScales::tare() {
   // scale emits on a physical tare press; verified live over BLE.
   // Format A7 00 01 [type=02] [sub=02] [param=01] [CK] 7A, CK=sum(bytes[2..5])&0xFF.
   static const uint8_t tareCmd[] = { 0xA7, 0x00, 0x01, 0x02, 0x02, 0x01, 0x06, 0x7A };
-  cmdCharacteristic->writeValue(const_cast<uint8_t*>(tareCmd), sizeof(tareCmd), false);
+  // write-WITH-response: the scale ACKs on FFF2 (verified: 12/12 acked on the
+  // bench), which both confirms delivery and serializes the write against the
+  // weight-notify stream so a shot-start tare is not dropped under load.
+  cmdCharacteristic->writeValue(const_cast<uint8_t*>(tareCmd), sizeof(tareCmd), true);
   return true;
 }
 


### PR DESCRIPTION
Follow-up to the IKAPE A01 plugin, addressing a reported intermittent tare during shots. Switches tare() from write-without-response to write-with-response on FFF2. Bench-verified: the scale ACKs reliably (12/12), and write-with-response serializes the tare against the weight-notify stream, which should prevent the write being dropped while the scale is streaming weight under load. tare() stays synchronous, same structure as the reference plugins. Not yet confirmed end-to-end on a live shot, that needs a firmware build that calls tare() at shot start, so flagging for review/testing on that side.